### PR TITLE
	coredump with double free or corruption in CoinWarmStartBasis::~CoinWarmStartBasis

### DIFF
--- a/CoinUtils/src/CoinWarmStartBasis.cpp
+++ b/CoinUtils/src/CoinWarmStartBasis.cpp
@@ -124,7 +124,7 @@ CoinWarmStartBasis::operator=(const CoinWarmStartBasis& rhs)
     int nintA = (numArtificial_+15) >> 4;
     int size = nintS+nintA;
     if (size>maxSize_) {
-			if(structuralStatus_ != NULL) {
+      if(structuralStatus_ != NULL) {
         delete[] structuralStatus_;
         structuralStatus_ = NULL;
       }

--- a/CoinUtils/src/CoinWarmStartBasis.cpp
+++ b/CoinUtils/src/CoinWarmStartBasis.cpp
@@ -28,7 +28,6 @@ CoinWarmStartBasis::setSize(int ns, int na) {
     if (size>maxSize_) {
       if(structuralStatus_ != NULL) {
         delete[] structuralStatus_;
-        structuralStatus_ = NULL;
       }
       maxSize_ = size+10;
       structuralStatus_ = new char[4*maxSize_];
@@ -54,7 +53,6 @@ CoinWarmStartBasis::assignBasisStatus(int ns, int na, char*& sStat,
     if (size>maxSize_) {
       if(structuralStatus_ != NULL) {
         delete[] structuralStatus_;
-        structuralStatus_ = NULL;
       }
       maxSize_ = size+10;
       structuralStatus_ = new char[4*maxSize_];
@@ -126,7 +124,6 @@ CoinWarmStartBasis::operator=(const CoinWarmStartBasis& rhs)
     if (size>maxSize_) {
       if(structuralStatus_ != NULL) {
         delete[] structuralStatus_;
-        structuralStatus_ = NULL;
       }
       maxSize_ = size+10;
       structuralStatus_ = new char[4*maxSize_];

--- a/CoinUtils/src/CoinWarmStartBasis.cpp
+++ b/CoinUtils/src/CoinWarmStartBasis.cpp
@@ -26,7 +26,10 @@ CoinWarmStartBasis::setSize(int ns, int na) {
   int size = nintS+nintA;
   if (size) {
     if (size>maxSize_) {
-      delete[] structuralStatus_;
+      if(structuralStatus_ != NULL) {
+        delete[] structuralStatus_;
+        structuralStatus_ = NULL;
+      }
       maxSize_ = size+10;
       structuralStatus_ = new char[4*maxSize_];
     }
@@ -49,7 +52,10 @@ CoinWarmStartBasis::assignBasisStatus(int ns, int na, char*& sStat,
   int size = nintS+nintA;
   if (size) {
     if (size>maxSize_) {
-      delete[] structuralStatus_;
+      if(structuralStatus_ != NULL) {
+        delete[] structuralStatus_;
+        structuralStatus_ = NULL;
+      }
       maxSize_ = size+10;
       structuralStatus_ = new char[4*maxSize_];
     }
@@ -118,7 +124,10 @@ CoinWarmStartBasis::operator=(const CoinWarmStartBasis& rhs)
     int nintA = (numArtificial_+15) >> 4;
     int size = nintS+nintA;
     if (size>maxSize_) {
-      delete[] structuralStatus_;
+			if(structuralStatus_ != NULL) {
+        delete[] structuralStatus_;
+        structuralStatus_ = NULL;
+      }
       maxSize_ = size+10;
       structuralStatus_ = new char[4*maxSize_];
     }
@@ -428,7 +437,10 @@ CoinWarmStartBasis::CoinWarmStartBasis()
 }
 CoinWarmStartBasis::~CoinWarmStartBasis()
 {
-  delete[] structuralStatus_;
+  if(structuralStatus_ != NULL) {
+    delete[] structuralStatus_;
+    structuralStatus_ = NULL;
+  }
 }
 // Returns number of basic structurals
 int


### PR DESCRIPTION
Hello,

Here is the code of resolving the following core dump:
```
#0  _int_free (av=0x7fe5ad22ee60, p=0x15319f40) at malloc.c:4890
4890    malloc.c: No such file or directory.
        in malloc.c
(gdb) bt full
#0  _int_free (av=0x7fe5ad22ee60, p=0x15319f40) at malloc.c:4890
        size = 192
        nextchunk = (mchunkptr) 0x1531a000
        nextsize = 67108848
        prevsize = <value optimized out>
        bck = (mchunkptr) 0x0
        fwd = (mchunkptr) 0x1
        errstr = 0x7fe5acffaf68 "double free or corruption (!prev)"
        __PRETTY_FUNCTION__ = "_int_free"
#1  0x00007fe5acf5138c in *__GI___libc_free (mem=<value optimized out>)
at malloc.c:3716
        ar_ptr = (mstate) 0x7fe5ad22ee60
        p = (mchunkptr) 0x1
#2  0x00007fe5b43a222c in ~CoinWarmStartBasis (this=0x15399820) at
src/CoinWarmStartBasis.cpp:431
No locals.
#3  0x00007fe5b4513d25 in CbcModel::doOneNode (this=0x151bf110,
baseModel=0x151bf110, node=@0x7fff9f5818d0, newNode=@0x7fff9f5819a0)
    at src/CbcModel.cpp:17178
        foundSolution = 0
        saveNumberCutGenerators = 6
        bestObjective = 3.8975173839662589
        onOptimalPath = false
        numberColumns = 254
        lowerBefore = (double *) 0x1539b730
        upperBefore = (double *) 0x153928d0
        feasible = false
        lastws = (class CoinWarmStartBasis *) 0x15399820
        save2 = 10
        retCode = 0
        branchesLeft = 1
        __PRETTY_FUNCTION__ = "int CbcModel::doOneNode(CbcModel*,
CbcNode*&, CbcNode*&)"
```

I hope this will help others.

Why everywhere is used new and delete instead of smart pointer classes?
This would help alot in solving this kind of issues.